### PR TITLE
Fix ResultsBag.__hash__() on 32 bit

### DIFF
--- a/pytest_harvest/tests/test_results_bag_basic.py
+++ b/pytest_harvest/tests/test_results_bag_basic.py
@@ -16,4 +16,6 @@ def test_results_bag_basic():
     assert dict(r) == {}
     assert str(r) == "ResultsBag:\n{}"
 
-    assert hash(r) == id(r)
+    # We need to call hash(), because id() might return a result outside of the
+    # range of hash(), Py_hash_t/Py_ssize_t. hash() is idempotent.
+    assert hash(r) == hash(id(r))


### PR DESCRIPTION
Fixes https://github.com/smarie/python-pytest-harvest/issues/26.

On 32 bit, id() returns an unsigned 32 bit integer, but Py_hash_t is
signed 32 bit, so the result doesn't fit in the range of [-2**32, 2**32),
and will get processed through the hash function for Py_Long to
coerce into the expected range.