### PR TITLE
fix variable scoping error

### DIFF
--- a/pytest_harvest/plugin.py
+++ b/pytest_harvest/plugin.py
@@ -242,9 +242,10 @@ try:
         return results_df
 
 except ImportError as e:
+    saved_e = e
     def get_session_results_df(*args, **kwargs):
         six.raise_from(Exception("There was an error importing `pandas` module. Fixture `session_results_df` and method"
-                                 "`get_session_results_df` can not be used in this session."), e)
+                                 "`get_session_results_df` can not be used in this session."), saved_e)
 
 
 @pytest.fixture(scope='function')
@@ -312,10 +313,11 @@ try:
         return results_df
 
 except ImportError as e:
+    saved_e = e
     def get_filtered_results_df(*args, **kwargs):
         six.raise_from(Exception("There was an error importing `pandas` module. Fixture `session_results_df` and "
                                  "methods `get_filtered_results_df` and `get_module_results_df` can not be used in this"
-                                 " session. "), e)
+                                 " session. "), saved_e)
 
 
 def get_module_results_df(session,


### PR DESCRIPTION
Due to the way the variable used in `except <exception> as <variable>`
is handled [1], it won't be in the scope of a function defined with
the `except` block.  It is necessary to first save the value to
another variable. Without this, execution that hits these except
blocks will fail with:

    NameError: name 'e' is not defined

[1] https://docs.python.org/3/reference/compound_stmts.html#the-try-statement