### PR TITLE
BUG: Fix use with doctest + fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+pytest_harvest/_version.py
 
 # Translations
 *.mo

--- a/pytest_harvest/plugin.py
+++ b/pytest_harvest/plugin.py
@@ -48,7 +48,7 @@ def pytest_runtest_makereport(item, call):
 
 # ------------- To collect benchmark results ------------
 FIXTURE_STORE = OrderedDict()
-"""The default fixture store, that is also available through the `fixture_store` fixture. It is recommended to access 
+"""The default fixture store, that is also available through the `fixture_store` fixture. It is recommended to access
 it through `get_fixture_store(session)` so as to be xdist-compliant"""
 
 
@@ -90,23 +90,23 @@ results_bag = create_results_bag_fixture('fixture_store', name='results_bag')
 A "results bag" fixture: a dictionary where you can store anything (results, context, etc.) during your tests execution.
 It offers a "much"-like api: you can access all entries using the object protocol such as in `results_bag.a = 1`.
 
-This fixture has function-scope so a new, empty instance is injected in each test node. 
+This fixture has function-scope so a new, empty instance is injected in each test node.
 
-There are several ways to gather all results after they have been stored. 
+There are several ways to gather all results after they have been stored.
 
- * To get the raw stored results, use the `fixture_store` fixture: `fixture_store['results_bag']` will contain all 
+ * To get the raw stored results, use the `fixture_store` fixture: `fixture_store['results_bag']` will contain all
    result bags for all tests.
-   
- * If you are interested in both the stored results AND some stored fixture values (through `@saved_fixture`), you 
+
+ * If you are interested in both the stored results AND some stored fixture values (through `@saved_fixture`), you
    might rather wish to leverage the following helpers:
 
-     - use one of the `session_results_dct`, `module_results_dct`, `session_results_df` or `module_results_df` 
+     - use one of the `session_results_dct`, `module_results_dct`, `session_results_df` or `module_results_df`
        fixtures. They contain all available information, in a nicely summarized way.
-       
-     - use the `get_session_synthesis_dct(session)` helper method to create a similar synthesis than the above with 
+
+     - use the `get_session_synthesis_dct(session)` helper method to create a similar synthesis than the above with
        more customization capabilities.
 
-If you wish to create custom results bags similar to this one (for example to create several with different names), 
+If you wish to create custom results bags similar to this one (for example to create several with different names),
 use `create_results_bag_fixture`.
 """
 
@@ -498,3 +498,14 @@ def possibly_restore_xdist_workers_structs(session):
                 else:
                     assert len(set(saved_fixture_dct.keys()).intersection(set(_saved_fixture_dct.keys()))) == 0
                     saved_fixture_dct.update(_saved_fixture_dct)
+
+
+def doctestable():
+    """Do nothing, but have a doctest.
+
+    Examples
+    --------
+    >>> 1 + 1
+    2
+    """
+    return

--- a/pytest_harvest/plugin.py
+++ b/pytest_harvest/plugin.py
@@ -498,14 +498,3 @@ def possibly_restore_xdist_workers_structs(session):
                 else:
                     assert len(set(saved_fixture_dct.keys()).intersection(set(_saved_fixture_dct.keys()))) == 0
                     saved_fixture_dct.update(_saved_fixture_dct)
-
-
-def doctestable():
-    """Do nothing, but have a doctest.
-
-    Examples
-    --------
-    >>> 1 + 1
-    2
-    """
-    return

--- a/pytest_harvest/results_session.py
+++ b/pytest_harvest/results_session.py
@@ -9,6 +9,7 @@ except ImportError:
     pass
 
 from pytest_harvest.common import HARVEST_PREFIX
+from _pytest.doctest import DoctestItem
 
 
 PYTEST_OBJ_NAME = 'pytest_obj'
@@ -324,6 +325,8 @@ def _pytest_item_matches_filter(item, filterset):
     # support class methods: the item object can be a bound method while the filter is maybe not
     elif _is_unbound_present(item_obj, filterset):
         return True
+    elif item_obj is None:
+        return False
     elif any(item_obj.__module__ == f for f in filterset):
         return True
     else:
@@ -443,6 +446,8 @@ def get_pytest_params(item):
     if isinstance(item, _MinimalItem):
         # Our special _MinimalItem object - when xdist is used and worker states have been saved + restored
         return item.get_pytest_params()
+    elif isinstance(item, DoctestItem):
+        return OrderedDict()
     else:
         param_dct = OrderedDict()
         for param_name in item.fixturenames:  # note: item.funcargnames gives the exact same list

--- a/pytest_harvest/results_session.py
+++ b/pytest_harvest/results_session.py
@@ -323,10 +323,11 @@ def _pytest_item_matches_filter(item, filterset):
     if item_obj in filterset:
         return True
     # support class methods: the item object can be a bound method while the filter is maybe not
+    elif item_obj is None:
+        # This can happen with DoctestItem
+        return False
     elif _is_unbound_present(item_obj, filterset):
         return True
-    elif item_obj is None:
-        return False
     elif any(item_obj.__module__ == f for f in filterset):
         return True
     else:
@@ -447,6 +448,7 @@ def get_pytest_params(item):
         # Our special _MinimalItem object - when xdist is used and worker states have been saved + restored
         return item.get_pytest_params()
     elif isinstance(item, DoctestItem):
+        # No fixtures or parameters
         return OrderedDict()
     else:
         param_dct = OrderedDict()

--- a/pytest_harvest/tests_raw/test_get_session_results.py
+++ b/pytest_harvest/tests_raw/test_get_session_results.py
@@ -210,11 +210,24 @@ def test_synthesis_contains_everything(request):
     assert len(missing) == 0
 
 
+def doctestable():
+    """Do nothing, but have a doctest.
+
+    Examples
+    --------
+    >>> 1 + 1
+    2
+    """
+    return
+
+
 # For some reason, adding a monkeypatch will cause an extra failure for
 # DoctestItem, possibly because it's a setup/teardown
-def test_deal_with_doctest(dummy):
+def test_deal_with_doctest(dummy, request):
     """ Tests that setup/teardown harvesting with DoctestItem works """
-    return
+    synth_dct = get_session_synthesis_dct(request, filter_incomplete=False)
+    assert 'pytest_harvest/tests_raw/test_get_session_results.py::pytest_harvest.tests_raw.test_get_session_results.doctestable' \
+        in synth_dct
 
 
 @yield_fixture(scope='session', autouse=True)

--- a/pytest_harvest/tests_raw/test_get_session_results.py
+++ b/pytest_harvest/tests_raw/test_get_session_results.py
@@ -1,5 +1,5 @@
 # META
-# {'passed': 16, 'skipped': 1, 'failed': 1}
+# {'passed': 17, 'skipped': 1, 'failed': 1}
 # END META
 import os
 from itertools import product
@@ -208,6 +208,13 @@ def test_synthesis_contains_everything(request):
     # check that synth_dct contains all these test nodes
     missing = set(these_tests) - set(synth_dct.keys())
     assert len(missing) == 0
+
+
+# For some reason, adding a monkeypatch will cause an extra failure for
+# DoctestItem, possibly because it's a setup/teardown
+def test_deal_with_doctest(dummy):
+    """ Tests that setup/teardown harvesting with DoctestItem works """
+    return
 
 
 @yield_fixture(scope='session', autouse=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,5 @@ description-file = README.md
 test=pytest
 
 [tool:pytest]
-addopts = --verbose
+addopts = --verbose --doctest-modules
 testpaths = pytest_harvest/tests

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs']),
+    packages=find_packages(exclude=['contrib', 'docs', '*tests*']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', '*tests*']),
+    packages=find_packages(exclude=['contrib', 'docs']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
Fixes #42

On `master` using `--doctest-modules` with fixtures leads to:
```
pytest_harvest/results_session.py:167: in get_session_synthesis_dct
    param_dct = get_pytest_params(item)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

item = <DoctestItem pytest_harvest.plugin.dummy>

    def get_pytest_params(item):
        """ Returns a dictionary containing a pytest session item's parameters """
    
        if isinstance(item, _MinimalItem):
            # Our special _MinimalItem object - when xdist is used and worker states have been saved + restored
            return item.get_pytest_params()
        else:
            param_dct = OrderedDict()
>           for param_name in item.fixturenames:  # note: item.funcargnames gives the exact same list
E           AttributeError: 'DoctestItem' object has no attribute 'fixturenames'
```
and also
```
pytest_harvest/results_session.py:234: in <genexpr>
    filtered_items = tuple(item for item in session.items if _pytest_item_matches_filter(item, filterset))
pytest_harvest/results_session.py:327: in _pytest_item_matches_filter
    elif any(item_obj.__module__ == f for f in filterset):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <set_iterator object at 0x7ffe00770140>

>   elif any(item_obj.__module__ == f for f in filterset):
E   AttributeError: 'NoneType' object has no attribute '__module__'
```

1. Added test that fails on `master` but passes here, along with dummy `doctestable` function
2. Adjusted META test count
3. Fixed code by adding a conditional that avoids trying to get param names from `DoctestItem`
4. Fixed code by adding a conditional for the `item_obj is None` case
5. Added `pytest_harvest/_version.py` to `.gitignore` (I assume this is useful?)
6. Removed some trailing whitespace (more PEP8-y; my editor did it automatically; can revert if preferred)

FWIW locally not all tests pass actually, but the same set that fail on this PR also fail on `master`.