### PR TITLE
Allow to overwrite fixture store when test rerun occurs.

### DIFF
--- a/src/pytest_harvest/fixture_cache.py
+++ b/src/pytest_harvest/fixture_cache.py
@@ -110,19 +110,11 @@ def saved_fixture(store='fixture_store',  # type: Union[str, Dict[str, Any]]
             # init
             if key not in store:
                 store[key] = OrderedDict()
-            # Check that the node id is unique
-            if nodeid in store[key]:
-                raise KeyError("Internal Error - This fixture '%s' was already "
-                               "stored for test id '%s'" % (key, nodeid))
 
         if views is not None:
             for k in views.keys():
                 if k not in store:
                     store[k] = OrderedDict()
-                # Check that the node id is unique
-                if nodeid in store[k]:
-                    raise KeyError("Internal Error - This fixture view '%s' was already "
-                                   "stored for test id '%s'" % (k, nodeid))
 
         return nodeid
 


### PR DESCRIPTION
Fixes https://github.com/smarie/python-pytest-harvest/issues/64